### PR TITLE
Fix null check error

### DIFF
--- a/lib/src/flexible_scrollbar.dart
+++ b/lib/src/flexible_scrollbar.dart
@@ -176,7 +176,7 @@ class _FlexibleScrollbarState extends State<FlexibleScrollbar> {
       scrollDirection: isScrolling
           ? widget.controller.position.axisDirection
           : scrollAxisDirection!,
-      thumbMainAxisSize: thumbMainAxisSize!,
+      thumbMainAxisSize: thumbMainAxisSize ?? 0,
       thumbMainAxisOffset: barOffset,
     );
   }


### PR DESCRIPTION
Avoid null check error when the child view hasn't a scrollable area. Typically when the list is empty.