### PR TITLE
Fix: thumbMainAxisMinSize in flexible_scrollbar.dart

### DIFF
--- a/lib/src/flexible_scrollbar.dart
+++ b/lib/src/flexible_scrollbar.dart
@@ -444,7 +444,7 @@ class _FlexibleScrollbarState extends State<FlexibleScrollbar> {
           isScrollable = true;
           double? thumbMinSize;
           if (widget.thumbMainAxisMinSize != null) {
-            thumbMinSize = thumbMinSize;
+            thumbMinSize = widget.thumbMainAxisMinSize;
           } else {
             thumbMinSize = mainAxisScrollAreaSize! * 0.1;
           }


### PR DESCRIPTION
https://github.com/ReliableCauliflower/flexible_scrollbar/blob/e32da4f5c2642c72a0ce8fc44fb663d1f7276636/lib/src/flexible_scrollbar.dart#L445-L450

`thumbMinSize = thumbMinSize; ` I think this is wrong